### PR TITLE
Added download folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To run it (with image on docker hub) :
 
     docker run -d -p 8989:8989 \
     -v /path_to_your_media_folder:/volumes/media \
+    -v /path_to_your_download_folder:/volumes/download \
     -v /path_to_your_config_folder:/volumes/config \
     -v /etc/localtime:/etc/localtime:ro \
     --restart unless-stopped \


### PR DESCRIPTION
When nzbget finishes the download of a file Sonarr wants to grab it and put it in the correct media folder.
Therefore i've added the download folder.